### PR TITLE
Don't include full module path in generated C function names

### DIFF
--- a/source/rock/middle/Module.ooc
+++ b/source/rock/middle/Module.ooc
@@ -62,8 +62,10 @@ Module: class extends Node {
             case =>
                 simpleName = this fullName substring(idx + 1)
         }
-
-        underName = sanitize(this fullName)
+        if (this fullName indexOf("lang/") == 0)
+            underName = sanitize(this fullName)
+        else
+            underName = sanitize(this simpleName)
 
         dead = false
     }


### PR DESCRIPTION
@simonmika wants to get rid of full module path from function names

For example, it changes 
```ooc
backend_gles3_include_gles3__glGenerateMipmap(((backend_GLTexture__GLTexture*)this)->_target);
```
into 
```ooc
gles3__glGenerateMipmap(((GLTexture__GLTexture*)this)->_target);
```

I don't know if it can cause problems when there are two classes with the same name in separate modules, maybe only if they interact with each other. However this is not the case now in our projects.
Some function names related to `lang` module are hard-coded in rock sources, we surely will have some fun trying to rename and move stuff which is hard-coded in compiler. For now these classes are not affected by this change.
@thomasfanell can you have a look at this
